### PR TITLE
Selection improvements

### DIFF
--- a/src/NodeEditorAvalonia/Behaviors/DrawingSelectionBehavior.cs
+++ b/src/NodeEditorAvalonia/Behaviors/DrawingSelectionBehavior.cs
@@ -258,7 +258,22 @@ public class DrawingSelectionBehavior : Behavior<ItemsControl>
             }
             else
             {
-                HitTestHelper.FindSelectedNodes(AssociatedObject, pointerHitTestRect);
+                // Add another node to the existing selection
+                if (e.KeyModifiers == KeyModifiers.Shift)
+                {
+                    HitTestHelper.FindSelectedNodesAndAddToSelection(AssociatedObject, pointerHitTestRect);
+                    
+                    var selectedRect = HitTestHelper.CalculateSelectedRect(AssociatedObject);
+
+                    _selectedRect = selectedRect;
+
+                    UpdateSelected(selectedRect);
+                }
+                // Clear the selection and select another
+                else
+                {
+                    HitTestHelper.FindSelectedNodes(AssociatedObject, pointerHitTestRect);
+                }
 
                 if (drawingNode.SelectedNodes is { Count: > 0 } || drawingNode.SelectedConnectors is { Count: > 0 })
                 {

--- a/src/NodeEditorAvalonia/HitTestHelper.cs
+++ b/src/NodeEditorAvalonia/HitTestHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.VisualTree;
@@ -182,7 +183,7 @@ internal static class HitTestHelper
 
         if (drawingNode.CanSelectNodes())
         {
-            foreach (var container in itemsControl.ItemContainerGenerator.Containers)
+            foreach (var container in itemsControl.ItemContainerGenerator.Containers.Reverse())
             {
                 if (container.ContainerControl is not { DataContext: INode node } containerControl)
                 {
@@ -199,6 +200,7 @@ internal static class HitTestHelper
                 if (node.CanSelect())
                 {
                     selectedNodes.Add(node);
+                    break;
                 }
             }
         }
@@ -207,7 +209,7 @@ internal static class HitTestHelper
         {
             if (drawingNode.Connectors is { Count: > 0 })
             {
-                foreach (var connector in drawingNode.Connectors)
+                foreach (var connector in drawingNode.Connectors.Reverse())
                 {
                     if (!HitTestConnector(connector, rect))
                     {
@@ -217,6 +219,7 @@ internal static class HitTestHelper
                     if (connector.CanSelect())
                     {
                         selectedConnectors.Add(connector);
+                        break;
                     }
                 }
             }

--- a/src/NodeEditorAvalonia/HitTestHelper.cs
+++ b/src/NodeEditorAvalonia/HitTestHelper.cs
@@ -235,6 +235,77 @@ internal static class HitTestHelper
             drawingNode.SelectedNodes = selectedNodes;
         }
     }
+    
+    public static void FindSelectedNodesAndAddToSelection(ItemsControl? itemsControl, Rect rect)
+    {
+        if (itemsControl?.DataContext is not IDrawingNode drawingNode)
+        {
+            return;
+        }
+
+        var selectedNodes = new HashSet<INode>();
+        var selectedConnectors = new HashSet<IConnector>();
+
+        if (drawingNode.CanSelectNodes())
+        {
+            foreach (var container in itemsControl.ItemContainerGenerator.Containers.Reverse())
+            {
+                if (container.ContainerControl is not { DataContext: INode node } containerControl)
+                {
+                    continue;
+                }
+
+                var bounds = containerControl.Bounds;
+
+                if (!rect.Intersects(bounds))
+                {
+                    continue;
+                }
+
+                if (node.CanSelect())
+                {
+                    selectedNodes.Add(node);
+                    break;
+                }
+            }
+        }
+
+        if (drawingNode.CanSelectConnectors())
+        {
+            if (drawingNode.Connectors is { Count: > 0 })
+            {
+                foreach (var connector in drawingNode.Connectors.Reverse())
+                {
+                    if (!HitTestConnector(connector, rect))
+                    {
+                        continue;
+                    }
+
+                    if (connector.CanSelect())
+                    {
+                        selectedConnectors.Add(connector);
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (selectedConnectors.Count > 0)
+        {
+            foreach (var selectedConnector in selectedConnectors)
+            {
+                drawingNode.SelectedConnectors?.Add(selectedConnector);
+            }
+        }
+
+        if (selectedNodes.Count > 0)
+        {
+            foreach (var selectedNode in selectedNodes)
+            {
+                drawingNode.SelectedNodes?.Add(selectedNode);
+            }
+        }
+    }
 
     public static Rect CalculateSelectedRect(ItemsControl? itemsControl)
     {


### PR DESCRIPTION
Old behaviour:
- when selecting a node while it is overlapping with another (or multiple others), every overlapping nodes where selected

new behaviour:
- when selecting a node while it is overlapping with another (or multiple others), only the top most rendered will be selected
- when a node is selected and you click on another node with the "shift" key pressed. The second node will be added to the selection.