### PR TITLE
fixing the web sample for Avalonia 11 preview 6

### DIFF
--- a/samples/NodeEditor.Web/AppBundle/main.js
+++ b/samples/NodeEditor.Web/AppBundle/main.js
@@ -1,5 +1,4 @@
 import { dotnet } from './dotnet.js'
-import { registerAvaloniaModule } from './avalonia.js';
 
 const is_browser = typeof window != "undefined";
 if (!is_browser) throw new Error(`Expected to be running in a browser`);
@@ -8,8 +7,6 @@ const dotnetRuntime = await dotnet
     .withDiagnosticTracing(false)
     .withApplicationArgumentsFromQuery()
     .create();
-
-await registerAvaloniaModule(dotnetRuntime);
 
 const config = dotnetRuntime.getConfig();
 


### PR DESCRIPTION
The current web sample gives the following error when starting: 
Uncaught SyntaxError: ambiguous indirect export: registerAvaloniaModule

https://wieslawsoltes.github.io/NodeEditor/ gives the same error.

This is because with preview 6 the `registerAvaloniaModule` function is not available anymore, so I removed it and it works again (locally). That is also the same I have done for the templates (https://github.com/AvaloniaUI/avalonia-dotnet-templates/pull/178/files#diff-ed60b642727cb049f2a36fb088d299c5deff9e1f5e9fe30f41d35e0314977664)