### PR TITLE
Upgrade NodeEditor to Avalonia 12.0.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>11.3.11.1</VersionPrefix>
+    <VersionPrefix>12.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Authors>Wiesław Šoltés</Authors>
     <Company>Wiesław Šoltés</Company>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,14 +4,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="11.3.11" />
-    <PackageVersion Include="Avalonia.Browser" Version="11.3.11" />
+    <PackageVersion Include="Avalonia" Version="12.0.0" />
+    <PackageVersion Include="Avalonia.Browser" Version="12.0.0" />
     <PackageVersion Include="Avalonia.Controls.PanAndZoom" Version="11.3.0" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.3.11" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.11" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.11" />
-    <PackageVersion Include="Avalonia.Skia" Version="11.3.11" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.11" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.0.0" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.0" />
+    <PackageVersion Include="Avalonia.HarfBuzz" Version="12.0.0" />
+    <PackageVersion Include="Avalonia.Skia" Version="12.0.0" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.0" />
     <PackageVersion Include="Avalonia.Xaml.Behaviors" Version="11.3.0.6" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
@@ -19,9 +19,11 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.102" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Nuke.Common" Version="10.1.0" />
+    <PackageVersion Include="ProDiagnostics" Version="12.0.0" />
     <PackageVersion Include="ReactiveMarbles.PropertyChanged" Version="2.0.27" />
     <PackageVersion Include="reactiveui" Version="22.3.1" />
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
+    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.92.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
     <PackageVersion Include="xunit.assert" Version="2.9.3" />

--- a/build/Avalonia.Desktop.props
+++ b/build/Avalonia.Desktop.props
@@ -2,5 +2,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <PackageReference Include="Avalonia.Desktop" />
+    <PackageReference Include="Avalonia.HarfBuzz" />
+    <PackageReference Include="Tmds.DBus.Protocol" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Diagnostics.props
+++ b/build/Avalonia.Diagnostics.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Diagnostics" />
+    <PackageReference Include="ProDiagnostics" />
   </ItemGroup>
 </Project>

--- a/samples/NodeEditor.Base/App.axaml.cs
+++ b/samples/NodeEditor.Base/App.axaml.cs
@@ -59,5 +59,8 @@ public class App : Application
         }
 
         base.OnFrameworkInitializationCompleted();
+#if DEBUG
+        this.AttachDevTools();
+#endif
     }
 }

--- a/samples/NodeEditor.Base/Views/MacroPickerWindow.axaml
+++ b/samples/NodeEditor.Base/Views/MacroPickerWindow.axaml
@@ -17,7 +17,7 @@
   </Window.KeyBindings>
   <DockPanel Margin="16">
     <TextBox DockPanel.Dock="Top"
-             Watermark="Filter macros..."
+             PlaceholderText="Filter macros..."
              Text="{Binding Filter, UpdateSourceTrigger=PropertyChanged}" />
     <ListBox ItemsSource="{Binding FilteredMacros}"
              SelectedItem="{Binding SelectedMacro}"

--- a/samples/NodeEditor.Base/Views/MainWindow.axaml
+++ b/samples/NodeEditor.Base/Views/MainWindow.axaml
@@ -14,7 +14,6 @@
         Background="{x:Null}"
         TransparencyLevelHint="AcrylicBlur"
         ExtendClientAreaToDecorationsHint="True"
-        ExtendClientAreaChromeHints="PreferSystemChrome"
         x:CompileBindings="True" x:DataType="vm:MainViewViewModel">
 
   <Design.DataContext>

--- a/samples/NodeEditor.Base/Views/MainWindow.axaml.cs
+++ b/samples/NodeEditor.Base/Views/MainWindow.axaml.cs
@@ -1,4 +1,3 @@
-using Avalonia;
 using Avalonia.Controls;
 
 namespace NodeEditorDemo.Views;
@@ -8,8 +7,5 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
-#if DEBUG
-        this.AttachDevTools();
-#endif
     }
 }

--- a/samples/NodeEditor.Desktop/Program.cs
+++ b/samples/NodeEditor.Desktop/Program.cs
@@ -40,5 +40,6 @@ class Program
         => AppBuilder.Configure<App>()
             .UsePlatformDetect()
             .LogToTrace()
-            .UseSkia();
+            .UseSkia()
+            .UseHarfBuzz();
 }

--- a/samples/NodeEditor.Logic.Desktop/Program.cs
+++ b/samples/NodeEditor.Logic.Desktop/Program.cs
@@ -40,5 +40,6 @@ class Program
         => AppBuilder.Configure<App>()
             .UsePlatformDetect()
             .LogToTrace()
-            .UseSkia();
+            .UseSkia()
+            .UseHarfBuzz();
 }

--- a/samples/NodeEditor.Logic/App.axaml.cs
+++ b/samples/NodeEditor.Logic/App.axaml.cs
@@ -64,5 +64,8 @@ public class App : Application
         }
 
         base.OnFrameworkInitializationCompleted();
+#if DEBUG
+        this.AttachDevTools();
+#endif
     }
 }

--- a/samples/NodeEditor.Logic/Views/MacroPickerWindow.axaml
+++ b/samples/NodeEditor.Logic/Views/MacroPickerWindow.axaml
@@ -17,7 +17,7 @@
   </Window.KeyBindings>
   <DockPanel Margin="16">
     <TextBox DockPanel.Dock="Top"
-             Watermark="Filter macros..."
+             PlaceholderText="Filter macros..."
              Text="{Binding Filter, UpdateSourceTrigger=PropertyChanged}" />
     <ListBox ItemsSource="{Binding FilteredMacros}"
              SelectedItem="{Binding SelectedMacro}"

--- a/samples/NodeEditor.Logic/Views/ToolboxView.axaml
+++ b/samples/NodeEditor.Logic/Views/ToolboxView.axaml
@@ -20,7 +20,7 @@
   <DockPanel Margin="12" ClipToBounds="True">
     <StackPanel DockPanel.Dock="Top" Spacing="8">
       <TextBlock Text="Toolbox" FontSize="14" FontWeight="SemiBold" />
-      <TextBox Text="{Binding ToolboxFilter}" Watermark="Search nodes" />
+      <TextBox Text="{Binding ToolboxFilter}" PlaceholderText="Search nodes" />
     </StackPanel>
 
     <ScrollViewer Margin="0,12,0,0">

--- a/src/NodeEditorAvalonia/Behaviors/ToolboxDragBehavior.cs
+++ b/src/NodeEditorAvalonia/Behaviors/ToolboxDragBehavior.cs
@@ -54,6 +54,7 @@ public class ToolboxDragBehavior : Behavior<Control>
         AvaloniaProperty.Register<ToolboxDragBehavior, double>(nameof(DragThreshold), 6);
 
     private Point? _dragStart;
+    private PointerPressedEventArgs? _dragStartEvent;
     private bool _dragging;
 
     public double DragThreshold
@@ -105,12 +106,14 @@ public class ToolboxDragBehavior : Behavior<Control>
         }
 
         _dragStart = e.GetPosition(AssociatedObject);
+        _dragStartEvent = e;
         e.Pointer.Capture(AssociatedObject);
     }
 
     private void OnPointerReleased(object? sender, PointerReleasedEventArgs e)
     {
         _dragStart = null;
+        _dragStartEvent = null;
         _dragging = false;
         if (AssociatedObject is not null && Equals(e.Pointer.Captured, AssociatedObject))
         {
@@ -121,12 +124,13 @@ public class ToolboxDragBehavior : Behavior<Control>
     private void OnPointerCaptureLost(object? sender, PointerCaptureLostEventArgs e)
     {
         _dragStart = null;
+        _dragStartEvent = null;
         _dragging = false;
     }
 
     private async void OnPointerMoved(object? sender, PointerEventArgs e)
     {
-        if (_dragStart is null || _dragging || AssociatedObject is null)
+        if (_dragStart is null || _dragStartEvent is null || _dragging || AssociatedObject is null)
         {
             return;
         }
@@ -134,6 +138,7 @@ public class ToolboxDragBehavior : Behavior<Control>
         if (!e.GetCurrentPoint(AssociatedObject).Properties.IsLeftButtonPressed)
         {
             _dragStart = null;
+            _dragStartEvent = null;
             return;
         }
 
@@ -148,11 +153,14 @@ public class ToolboxDragBehavior : Behavior<Control>
         if (AssociatedObject.DataContext is not INodeTemplate template)
         {
             _dragStart = null;
+            _dragStartEvent = null;
             return;
         }
 
         _dragging = true;
         _dragStart = null;
+        var dragStartEvent = _dragStartEvent;
+        _dragStartEvent = null;
 
         try
         {
@@ -176,7 +184,7 @@ public class ToolboxDragBehavior : Behavior<Control>
 
             data.Add(item);
 
-            await DragDrop.DoDragDropAsync(e, data, DragDropEffects.Copy);
+            await DragDrop.DoDragDropAsync(dragStartEvent, data, DragDropEffects.Copy);
         }
         finally
         {

--- a/src/NodeEditorAvalonia/NodeEditorAvalonia.csproj
+++ b/src/NodeEditorAvalonia/NodeEditorAvalonia.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <IsPackable>True</IsPackable>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
@@ -19,7 +19,7 @@
   <Import Project="..\..\build\Avalonia.props" />
   <Import Project="..\..\build\Avalonia.Xaml.Behaviors.props" />
   <Import Project="..\..\build\Avalonia.Controls.PanAndZoom.props" />
-  <Import Project="..\..\build\Avalonia.Skia.props" Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net10.0'" />
+  <Import Project="..\..\build\Avalonia.Skia.props" Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'" />
 
   <ItemGroup>
     <ProjectReference Include="..\NodeEditorAvalonia.Model\NodeEditorAvalonia.Model.csproj" />

--- a/src/NodeEditorAvalonia/Services/ExportRenderer.cs
+++ b/src/NodeEditorAvalonia/Services/ExportRenderer.cs
@@ -1,13 +1,9 @@
 using System;
 using System.IO;
-#if NET6_0_OR_GREATER
-using System.Reflection;
-#endif
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media.Imaging;
 #if NET6_0_OR_GREATER
-using Avalonia.Media;
 using Avalonia.Skia.Helpers;
 using SkiaSharp;
 #endif
@@ -17,144 +13,12 @@ namespace NodeEditor.Services;
 public static class ExportRenderer
 {
 #if NET6_0_OR_GREATER
-    private static MethodInfo? _immediateRenderMethod;
-    private static int _immediateRenderParameterCount;
-
     private static void Render(Control target, SKCanvas canvas, double dpi = 96)
     {
-        using var drawingContextImpl = DrawingContextHelper.WrapSkiaCanvas(canvas, new Vector(dpi, dpi));
-        var platformDrawingContextType = typeof(DrawingContext).Assembly.GetType("Avalonia.Media.PlatformDrawingContext");
-        if (platformDrawingContextType is not null)
-        {
-            var drawingContext = (DrawingContext?)Activator.CreateInstance(
-                platformDrawingContextType,
-                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
-                null,
-                new object?[] { drawingContextImpl, true },
-                null);
-            if (drawingContext is not null)
-            {
-                if (!TryImmediateRender(target, drawingContext))
-                {
-                    throw new NotSupportedException("Immediate renderer was not found.");
-                }
-            }
-        }
-        else
-        {
-            throw new NotSupportedException("Platform drawing context type was not found.");
-        }
-    }
-
-    private static bool TryImmediateRender(Control target, DrawingContext drawingContext)
-    {
-        _immediateRenderMethod ??= ResolveImmediateRenderMethod();
-        if (_immediateRenderMethod is null)
-        {
-            return false;
-        }
-
-        var parameterCount = _immediateRenderParameterCount;
-        if (parameterCount <= 2)
-        {
-            _immediateRenderMethod.Invoke(null, new object?[] { target, drawingContext });
-            return true;
-        }
-
-        var args = new object?[parameterCount];
-        args[0] = target;
-        args[1] = drawingContext;
-        for (var i = 2; i < parameterCount; i++)
-        {
-            args[i] = Type.Missing;
-        }
-
-        _immediateRenderMethod.Invoke(null, args);
-        return true;
-    }
-
-    private static MethodInfo? ResolveImmediateRenderMethod()
-    {
-        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
-        {
-            var type = assembly.GetType("Avalonia.Rendering.ImmediateRenderer", throwOnError: false)
-                       ?? FindTypeByName(assembly, "ImmediateRenderer");
-
-            if (type is null)
-            {
-                continue;
-            }
-
-            foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static))
-            {
-                if (!string.Equals(method.Name, "Render", StringComparison.Ordinal))
-                {
-                    continue;
-                }
-
-                var parameters = method.GetParameters();
-                if (parameters.Length < 2)
-                {
-                    continue;
-                }
-
-                if (!parameters[0].ParameterType.IsAssignableFrom(typeof(Control)))
-                {
-                    continue;
-                }
-
-                if (!parameters[1].ParameterType.IsAssignableFrom(typeof(DrawingContext)))
-                {
-                    continue;
-                }
-
-                var valid = true;
-                for (var i = 2; i < parameters.Length; i++)
-                {
-                    if (!parameters[i].IsOptional)
-                    {
-                        valid = false;
-                        break;
-                    }
-                }
-
-                if (!valid)
-                {
-                    continue;
-                }
-
-                _immediateRenderParameterCount = parameters.Length;
-                return method;
-            }
-        }
-
-        return null;
-    }
-
-    private static Type? FindTypeByName(Assembly assembly, string name)
-    {
-        try
-        {
-            foreach (var type in assembly.GetTypes())
-            {
-                if (type.Name == name)
-                {
-                    return type;
-                }
-            }
-        }
-        catch (ReflectionTypeLoadException ex)
-        {
-            foreach (var type in ex.Types)
-            {
-                if (type?.Name == name)
-                {
-                    return type;
-                }
-            }
-        }
-
-        return null;
+        DrawingContextHelper
+            .RenderAsync(canvas, target, new Rect(target.Bounds.Size), new Vector(dpi, dpi))
+            .GetAwaiter()
+            .GetResult();
     }
 #endif
 

--- a/src/NodeEditorAvalonia/Services/StorageService.cs
+++ b/src/NodeEditorAvalonia/Services/StorageService.cs
@@ -2,7 +2,6 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Platform.Storage;
-using Avalonia.VisualTree;
 
 namespace NodeEditor.Services;
 
@@ -65,8 +64,8 @@ public static class StorageService
 
         if (Application.Current?.ApplicationLifetime is ISingleViewApplicationLifetime { MainView: { } mainView })
         {
-            var visualRoot = mainView.GetVisualRoot();
-            if (visualRoot is TopLevel topLevel)
+            var topLevel = TopLevel.GetTopLevel(mainView);
+            if (topLevel is not null)
             {
                 return topLevel.StorageProvider;
             }

--- a/src/NodeEditorAvalonia/Themes/Controls/Connector.axaml
+++ b/src/NodeEditorAvalonia/Themes/Controls/Connector.axaml
@@ -102,7 +102,7 @@
                            DockPanel.Dock="Top" />
             </DockPanel>
             <Label Content="Label:" DockPanel.Dock="Top" />
-            <TextBox Text="{Binding ConnectorSource.Name}" Watermark="Label" DockPanel.Dock="Top" />
+            <TextBox Text="{Binding ConnectorSource.Name}" PlaceholderText="Label" DockPanel.Dock="Top" />
           </DockPanel>
         </Flyout>
       </Setter.Value>


### PR DESCRIPTION
# Avalonia 12 Upgrade

## Summary

This PR upgrades the NodeEditor repository to Avalonia `12.0.0` and aligns the repository package version to `12.0.0`.

The change set includes:

- central package/version updates for the Avalonia 12 line,
- replacement of the old diagnostics package with `ProDiagnostics`,
- required source migrations for Avalonia 12 API changes,
- desktop startup updates for explicit HarfBuzz registration,
- XAML cleanup for deprecated placeholder APIs,
- an explicit override for the vulnerable transitive `Tmds.DBus.Protocol` desktop dependency.

## Commit Breakdown

### 1. `Upgrade packages to Avalonia 12.0.0`

Updates the central version definitions and package wiring:

- bumps `Avalonia`, `Avalonia.Desktop`, `Avalonia.Skia`, `Avalonia.Fonts.Inter`, and `Avalonia.Themes.Fluent` to `12.0.0`,
- sets the repository package version to `12.0.0`,
- swaps debug diagnostics package wiring from `Avalonia.Diagnostics` to `ProDiagnostics`,
- updates `NodeEditorAvalonia` target frameworks from `netstandard2.0;net6.0;net10.0` to `net8.0;net10.0` to match the Avalonia 12 runtime baseline.

### 2. `Adapt library APIs for Avalonia 12`

Updates the Avalonia-backed library code to use supported Avalonia 12 APIs:

- replaces `GetVisualRoot()`-based `StorageProvider` lookup with `TopLevel.GetTopLevel(...)`,
- updates toolbox drag initiation to keep and forward the original `PointerPressedEventArgs`, which is now required by Avalonia 12 drag/drop,
- replaces the old reflection-based Skia/immediate-renderer export path with the public Avalonia 12 `DrawingContextHelper.RenderAsync(...)` helper.

### 3. `Update desktop startup and XAML for Avalonia 12`

Applies app and XAML migration fixes:

- adds `.UseHarfBuzz()` to both desktop app bootstraps because the apps explicitly call `.UseSkia()`,
- moves DevTools attachment into the `Application` initialization path used by `ProDiagnostics`,
- removes obsolete `ExtendClientAreaChromeHints`,
- replaces deprecated `TextBox.Watermark` usage with `PlaceholderText`.

### 4. `Override vulnerable desktop D-Bus dependency`

Mitigates the `NU1903` restore/build warning from Avalonia's desktop dependency graph:

- adds an explicit desktop reference to `Tmds.DBus.Protocol`,
- pins the resolved version to `0.92.0` via central package management,
- removes the warning for both desktop builds without suppressing vulnerability checks.

## Detailed Change Notes

### Package and Build Changes

- `Directory.Packages.props`
  - Avalonia packages updated to `12.0.0`.
  - `ProDiagnostics` added.
  - `Tmds.DBus.Protocol` pinned to `0.92.0`.
- `Directory.Build.props`
  - `VersionPrefix` updated to `12.0.0`.
- `build/Avalonia.Diagnostics.props`
  - now references `ProDiagnostics`.
- `build/Avalonia.Desktop.props`
  - now references `Avalonia.HarfBuzz` and the D-Bus override package.

### Runtime and App Startup

- `samples/NodeEditor.Desktop/Program.cs`
- `samples/NodeEditor.Logic.Desktop/Program.cs`

Both desktop app builders now call:

```csharp
.UseSkia()
.UseHarfBuzz();
```

This keeps the startup aligned with Avalonia 12 when Skia is configured explicitly.

### Diagnostics

- `samples/NodeEditor.Base/App.axaml.cs`
- `samples/NodeEditor.Logic/App.axaml.cs`

Debug-time DevTools attachment is now done via:

```csharp
this.AttachDevTools();
```

This aligns the apps with the `ProDiagnostics` package that replaced `Avalonia.Diagnostics`.

### Avalonia 12 API Migrations

- `src/NodeEditorAvalonia/Services/StorageService.cs`
  - uses `TopLevel.GetTopLevel(...)` instead of assuming `GetVisualRoot()` returns a usable `TopLevel`.
- `src/NodeEditorAvalonia/Behaviors/ToolboxDragBehavior.cs`
  - preserves the original press event so `DragDrop.DoDragDropAsync(...)` gets the required `PointerPressedEventArgs`.
- `src/NodeEditorAvalonia/Services/ExportRenderer.cs`
  - removes the private reflection path that searched for the immediate renderer,
  - uses Avalonia 12's public Skia rendering helper instead.

### XAML Cleanup

- `samples/NodeEditor.Base/Views/MainWindow.axaml`
  - removes obsolete `ExtendClientAreaChromeHints`.
- `samples/NodeEditor.Base/Views/MacroPickerWindow.axaml`
- `samples/NodeEditor.Logic/Views/MacroPickerWindow.axaml`
- `samples/NodeEditor.Logic/Views/ToolboxView.axaml`
- `src/NodeEditorAvalonia/Themes/Controls/Connector.axaml`
  - replace `Watermark` with `PlaceholderText`.

## Validation Performed

The following validations were run successfully against the final change set:

### Build

- `dotnet build samples/NodeEditor.Desktop/NodeEditor.Desktop.csproj -v minimal`
- `dotnet build samples/NodeEditor.Logic.Desktop/NodeEditor.Logic.Desktop.csproj -v minimal`

Result:

- both desktop builds succeed,
- both desktop builds finish with `0 warning(s)` and `0 error(s)`.

### Tests

- `dotnet test tests/NodeEditorAvalonia.UnitTests/NodeEditorAvalonia.UnitTests.csproj -v minimal`

Result:

- `Passed: 5, Failed: 0, Skipped: 0`.

### Packaging

- `dotnet pack src/NodeEditorAvalonia/NodeEditorAvalonia.csproj -c Release -o /tmp/nodeeditor-pack-review2`

Checked output:

- package creation succeeds,
- `NodeEditorAvalonia.12.0.0.nupkg` now targets `net8.0` and `net10.0`,
- the final package metadata no longer carries `Avalonia.HarfBuzz` as a library dependency; it is scoped to desktop startup only.

## Risks / Follow-Ups

### Third-Party Avalonia Ecosystem Packages

The repository still consumes:

- `Avalonia.Controls.PanAndZoom` `11.3.0`
- `Avalonia.Xaml.Behaviors` `11.3.0.6`

These packages restore and build successfully with Avalonia `12.0.0` in this repository, but they are not published as `12.x` packages on NuGet at the time of this upgrade. If upstream publishes Avalonia 12-native releases later, this repo should consider moving to those versions.

### Export Path Test Coverage

The Skia export path was migrated to the public Avalonia 12 rendering helper. It compiles and the repository builds/tests pass, but there is still no dedicated automated test coverage for SVG/PDF/XPS/SKP export behavior. Adding a small headless export regression test would reduce future migration risk.

## Suggested PR Title

`Upgrade NodeEditor to Avalonia 12.0.0`

## Suggested Reviewer Focus

- Verify export output behavior after the `ExportRenderer` rewrite.
- Confirm desktop DevTools behavior with `ProDiagnostics`.
- Sanity-check window chrome on Windows/macOS/Linux because Avalonia 12 changed managed/system decoration behavior.
- Review whether the repo wants to keep shipping sample packages (`NodeEditor.Base`, `NodeEditor.Logic`) at version `12.0.0`, since this PR aligned all package versions with the Avalonia major line.

Fixes https://github.com/wieslawsoltes/NodeEditor/issues/71
