### PR TITLE
chore: Update package versions and migrate from obsolete packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,26 +4,26 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.Browser" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.Controls.PanAndZoom" Version="11.3.0" />
-    <PackageVersion Include="Avalonia.Desktop" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.HarfBuzz" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.Skia" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.Xaml.Behaviors" Version="11.3.0.6" />
+    <PackageVersion Include="Avalonia" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Browser" Version="12.1.0" />
+    <PackageVersion Include="PanAndZoom" Version="12.0.0.1" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.HarfBuzz" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Skia" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.0" />
+    <PackageVersion Include="Xaml.Behaviors.Avalonia" Version="12.0.5" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.102" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Nuke.Common" Version="10.1.0" />
-    <PackageVersion Include="ProDiagnostics" Version="12.0.0" />
+    <PackageVersion Include="ProDiagnostics" Version="12.0.4" />
     <PackageVersion Include="ReactiveMarbles.PropertyChanged" Version="2.0.27" />
     <PackageVersion Include="reactiveui" Version="22.3.1" />
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
-    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.92.0" />
+    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.94.2" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
     <PackageVersion Include="xunit.assert" Version="2.9.3" />

--- a/build/Avalonia.Controls.PanAndZoom.props
+++ b/build/Avalonia.Controls.PanAndZoom.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Controls.PanAndZoom" />
+    <PackageReference Include="PanAndZoom"/>
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Xaml.Behaviors.props
+++ b/build/Avalonia.Xaml.Behaviors.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Xaml.Behaviors" />
+    <PackageReference Include="Xaml.Behaviors.Avalonia"/>
   </ItemGroup>
 </Project>

--- a/samples/NodeEditor.Logic/Views/ToolboxView.axaml
+++ b/samples/NodeEditor.Logic/Views/ToolboxView.axaml
@@ -6,9 +6,7 @@
              xmlns:views="clr-namespace:NodeEditorLogic.Views"
              xmlns:m="clr-namespace:NodeEditor.Model;assembly=NodeEditorAvalonia.Model"
              xmlns:controls="clr-namespace:NodeEditor.Controls;assembly=NodeEditorAvalonia"
-             xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
              xmlns:behaviors="clr-namespace:NodeEditor.Behaviors;assembly=NodeEditorAvalonia"
-             xmlns:converters="clr-namespace:NodeEditorLogic.Converters;assembly=NodeEditorLogic.Editor"
              mc:Ignorable="d" d:DesignWidth="240" d:DesignHeight="600"
              x:Class="NodeEditorLogic.Views.ToolboxView"
              x:CompileBindings="False" x:DataType="vm:MainViewViewModel">
@@ -39,13 +37,13 @@
                   <Style Selector="ListBox > ListBoxItem">
                     <Setter Property="HorizontalAlignment" Value="Stretch" />
                     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                    <Setter Property="(i:Interaction.Behaviors)">
-                      <i:BehaviorCollectionTemplate>
-                        <i:BehaviorCollection>
+                    <Setter Property="(Interaction.Behaviors)">
+                      <BehaviorCollectionTemplate>
+                        <BehaviorCollection>
                           <behaviors:ToolboxDragBehavior />
                           <behaviors:InsertTemplateOnDoubleTappedBehavior DrawingSource="{Binding DataContext.Editor.Drawing, RelativeSource={RelativeSource AncestorType=views:ToolboxView}}" />
-                        </i:BehaviorCollection>
-                      </i:BehaviorCollectionTemplate>
+                        </BehaviorCollection>
+                      </BehaviorCollectionTemplate>
                     </Setter>
                   </Style>
                 </ListBox.Styles>

--- a/src/NodeEditorAvalonia/Behaviors/ToolboxDragBehavior.cs
+++ b/src/NodeEditorAvalonia/Behaviors/ToolboxDragBehavior.cs
@@ -15,7 +15,7 @@ public class ToolboxDragBehavior : Behavior<Control>
     private const string ApplicationPrefix = "";
     // DataFormat.FromSystemName isn't in netstandard reference assemblies, so resolve via reflection.
     private static readonly MethodInfo? FromSystemNameMethod = ResolveFromSystemNameMethod();
-    private static readonly DataFormat<INodeTemplate>? ContextTemplateFormat = CreateTemplateFormat(ContextDropBehavior.DataFormat);
+    private static readonly DataFormat<INodeTemplate>? ContextTemplateFormat = CreateTemplateFormat(nameof(ContextDropBehavior.Context));
     private static readonly DataFormat<INodeTemplate>? NodeTemplateFormat = CreateTemplateFormat("NodeTemplate");
 
     private static MethodInfo? ResolveFromSystemNameMethod()

--- a/src/NodeEditorAvalonia/Themes/Controls/Connectors.axaml
+++ b/src/NodeEditorAvalonia/Themes/Controls/Connectors.axaml
@@ -3,7 +3,7 @@
                     xmlns:m="clr-namespace:NodeEditor.Model;assembly=NodeEditorAvalonia.Model"
                     xmlns:converters="clr-namespace:NodeEditor.Converters"
                     xmlns:controls="clr-namespace:NodeEditor.Controls"
-                    xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
+                    xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Xaml.Behaviors.Interactivity"
                     xmlns:behaviors="clr-namespace:NodeEditor.Behaviors;assembly=NodeEditorAvalonia"
                     x:CompileBindings="True">
 

--- a/src/NodeEditorAvalonia/Themes/Controls/Editor.axaml
+++ b/src/NodeEditorAvalonia/Themes/Controls/Editor.axaml
@@ -2,8 +2,6 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="clr-namespace:NodeEditor.Controls"
                     xmlns:m="clr-namespace:NodeEditor.Model;assembly=NodeEditorAvalonia.Model"
-                    xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
-                    xmlns:idd="clr-namespace:Avalonia.Xaml.Interactions.DragAndDrop;assembly=Avalonia.Xaml.Interactions.DragAndDrop"
                     xmlns:input="clr-namespace:Avalonia.Input;assembly=Avalonia.Base"
                     xmlns:behaviors="clr-namespace:NodeEditor.Behaviors"
                     x:CompileBindings="True">
@@ -34,14 +32,14 @@
                                      input:DragDrop.AllowDrop="True"
                                      VerticalAlignment="Stretch" 
                                      HorizontalAlignment="Stretch">
-              <i:Interaction.Behaviors>
-                <idd:ContextDropBehavior Context="{Binding DrawingSource, RelativeSource={RelativeSource TemplatedParent}}">
-                  <idd:ContextDropBehavior.Handler>
+              <Interaction.Behaviors>
+                <ContextDropBehavior Context="{Binding DrawingSource, RelativeSource={RelativeSource TemplatedParent}}">
+                  <ContextDropBehavior.Handler>
                     <behaviors:DrawingDropHandler DrawingSource="{Binding DrawingSource, RelativeSource={RelativeSource TemplatedParent}}"
                                                   RelativeTo="{Binding #PART_DrawingNode}" />
-                  </idd:ContextDropBehavior.Handler>
-                </idd:ContextDropBehavior>
-              </i:Interaction.Behaviors>
+                  </ContextDropBehavior.Handler>
+                </ContextDropBehavior>
+              </Interaction.Behaviors>
               <Border Background="Transparent"
                       Width="{Binding DrawingSource.Width, RelativeSource={RelativeSource TemplatedParent}}"
                       Height="{Binding DrawingSource.Height, RelativeSource={RelativeSource TemplatedParent}}"

--- a/src/NodeEditorAvalonia/Themes/Controls/Node.axaml
+++ b/src/NodeEditorAvalonia/Themes/Controls/Node.axaml
@@ -1,7 +1,6 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="clr-namespace:NodeEditor.Controls"
-                    xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
                     xmlns:behaviors="clr-namespace:NodeEditor.Behaviors"
                     xmlns:primitives="clr-namespace:Avalonia.Controls.Primitives;assembly=Avalonia.Controls"
                     x:CompileBindings="True">
@@ -69,77 +68,77 @@
                               Cursor="TopLeftCorner"
                               Grid.Row="0"
                               Grid.Column="0">
-              <i:Interaction.Behaviors>
+              <Interaction.Behaviors>
                 <behaviors:NodeResizeBehavior NodeSource="{Binding NodeSource, RelativeSource={RelativeSource TemplatedParent}}"
                                               Direction="TopLeft" />
-              </i:Interaction.Behaviors>
+              </Interaction.Behaviors>
             </primitives:Thumb>
             <primitives:Thumb Classes="resize-handle"
                               Cursor="SizeNorthSouth"
                               Grid.Row="0"
                               Grid.Column="1"
                               HorizontalAlignment="Center">
-              <i:Interaction.Behaviors>
+              <Interaction.Behaviors>
                 <behaviors:NodeResizeBehavior NodeSource="{Binding NodeSource, RelativeSource={RelativeSource TemplatedParent}}"
                                               Direction="Top" />
-              </i:Interaction.Behaviors>
+              </Interaction.Behaviors>
             </primitives:Thumb>
             <primitives:Thumb Classes="resize-handle"
                               Cursor="TopRightCorner"
                               Grid.Row="0"
                               Grid.Column="2">
-              <i:Interaction.Behaviors>
+              <Interaction.Behaviors>
                 <behaviors:NodeResizeBehavior NodeSource="{Binding NodeSource, RelativeSource={RelativeSource TemplatedParent}}"
                                               Direction="TopRight" />
-              </i:Interaction.Behaviors>
+              </Interaction.Behaviors>
             </primitives:Thumb>
             <primitives:Thumb Classes="resize-handle"
                               Cursor="SizeWestEast"
                               Grid.Row="1"
                               Grid.Column="0"
                               VerticalAlignment="Center">
-              <i:Interaction.Behaviors>
+              <Interaction.Behaviors>
                 <behaviors:NodeResizeBehavior NodeSource="{Binding NodeSource, RelativeSource={RelativeSource TemplatedParent}}"
                                               Direction="Left" />
-              </i:Interaction.Behaviors>
+              </Interaction.Behaviors>
             </primitives:Thumb>
             <primitives:Thumb Classes="resize-handle"
                               Cursor="SizeWestEast"
                               Grid.Row="1"
                               Grid.Column="2"
                               VerticalAlignment="Center">
-              <i:Interaction.Behaviors>
+              <Interaction.Behaviors>
                 <behaviors:NodeResizeBehavior NodeSource="{Binding NodeSource, RelativeSource={RelativeSource TemplatedParent}}"
                                               Direction="Right" />
-              </i:Interaction.Behaviors>
+              </Interaction.Behaviors>
             </primitives:Thumb>
             <primitives:Thumb Classes="resize-handle"
                               Cursor="BottomLeftCorner"
                               Grid.Row="2"
                               Grid.Column="0">
-              <i:Interaction.Behaviors>
+              <Interaction.Behaviors>
                 <behaviors:NodeResizeBehavior NodeSource="{Binding NodeSource, RelativeSource={RelativeSource TemplatedParent}}"
                                               Direction="BottomLeft" />
-              </i:Interaction.Behaviors>
+              </Interaction.Behaviors>
             </primitives:Thumb>
             <primitives:Thumb Classes="resize-handle"
                               Cursor="SizeNorthSouth"
                               Grid.Row="2"
                               Grid.Column="1"
                               HorizontalAlignment="Center">
-              <i:Interaction.Behaviors>
+              <Interaction.Behaviors>
                 <behaviors:NodeResizeBehavior NodeSource="{Binding NodeSource, RelativeSource={RelativeSource TemplatedParent}}"
                                               Direction="Bottom" />
-              </i:Interaction.Behaviors>
+              </Interaction.Behaviors>
             </primitives:Thumb>
             <primitives:Thumb Classes="resize-handle"
                               Cursor="BottomRightCorner"
                               Grid.Row="2"
                               Grid.Column="2">
-              <i:Interaction.Behaviors>
+              <Interaction.Behaviors>
                 <behaviors:NodeResizeBehavior NodeSource="{Binding NodeSource, RelativeSource={RelativeSource TemplatedParent}}"
                                               Direction="BottomRight" />
-              </i:Interaction.Behaviors>
+              </Interaction.Behaviors>
             </primitives:Thumb>
           </Grid>
           <primitives:Thumb Classes="rotate-handle"
@@ -149,12 +148,12 @@
                             Margin="0,-18,0,0"
                             IsVisible="False"
                             IsHitTestVisible="False">
-            <i:Interaction.Behaviors>
+            <Interaction.Behaviors>
               <behaviors:NodeRotateBehavior NodeSource="{Binding NodeSource, RelativeSource={RelativeSource TemplatedParent}}"
                                             AngleReadoutBackground="{DynamicResource RotationSnapReadoutBackgroundBrush}"
                                             AngleReadoutBorderBrush="{DynamicResource RotationSnapReadoutBorderBrush}"
                                             AngleReadoutForeground="{DynamicResource RotationSnapReadoutForegroundBrush}" />
-            </i:Interaction.Behaviors>
+            </Interaction.Behaviors>
           </primitives:Thumb>
         </Panel>
       </ControlTemplate>

--- a/src/NodeEditorAvalonia/Themes/Controls/Nodes.axaml
+++ b/src/NodeEditorAvalonia/Themes/Controls/Nodes.axaml
@@ -1,7 +1,6 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:m="clr-namespace:NodeEditor.Model;assembly=NodeEditorAvalonia.Model"
-                    xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
                     xmlns:behaviors="clr-namespace:NodeEditor.Behaviors"
                     xmlns:controls="clr-namespace:NodeEditor.Controls"
                     x:CompileBindings="True">
@@ -17,7 +16,7 @@
                       Width="{Binding Width, RelativeSource={RelativeSource TemplatedParent}}" 
                       Height="{Binding Height, RelativeSource={RelativeSource TemplatedParent}}"
                       ClipToBounds="False">
-          <i:Interaction.Behaviors>
+          <Interaction.Behaviors>
             <behaviors:NodesSelectedBehavior DrawingSource="{Binding DrawingSource, RelativeSource={RelativeSource TemplatedParent}}" />
             <behaviors:DrawingSelectionBehavior DrawingSource="{Binding DrawingSource, RelativeSource={RelativeSource TemplatedParent}}" 
                                                 InputSource="{Binding InputSource, RelativeSource={RelativeSource TemplatedParent}}" 
@@ -35,7 +34,7 @@
                                             InputSource="{Binding InputSource, RelativeSource={RelativeSource TemplatedParent}}" />
             <behaviors:DrawingReleasedBehavior DrawingSource="{Binding DrawingSource, RelativeSource={RelativeSource TemplatedParent}}"
                                                InputSource="{Binding InputSource, RelativeSource={RelativeSource TemplatedParent}}" />
-          </i:Interaction.Behaviors>
+          </Interaction.Behaviors>
           <ItemsControl.ItemContainerTheme>
             <ControlTheme TargetType="ContentPresenter" x:DataType="m:INode">
               <Setter Property="Canvas.Left" Value="{Binding X}" />

--- a/src/NodeEditorAvalonia/Themes/Controls/Pins.axaml
+++ b/src/NodeEditorAvalonia/Themes/Controls/Pins.axaml
@@ -1,7 +1,6 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:m="clr-namespace:NodeEditor.Model;assembly=NodeEditorAvalonia.Model"
-                    xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
                     xmlns:behaviors="clr-namespace:NodeEditor.Behaviors"
                     xmlns:controls="clr-namespace:NodeEditor.Controls"
                     x:CompileBindings="True">
@@ -21,12 +20,12 @@
             <ControlTheme TargetType="ContentPresenter" x:DataType="m:IPin">
               <Setter Property="Canvas.Left" Value="{Binding X}" />
               <Setter Property="Canvas.Top" Value="{Binding Y}" />
-              <Setter Property="(i:Interaction.Behaviors)">
-                <i:BehaviorCollectionTemplate>
-                  <i:BehaviorCollection>
+              <Setter Property="(Interaction.Behaviors)">
+                <BehaviorCollectionTemplate>
+                  <BehaviorCollection>
                     <behaviors:PinPressedBehavior />
-                  </i:BehaviorCollection>
-                </i:BehaviorCollectionTemplate>
+                  </BehaviorCollection>
+                </BehaviorCollectionTemplate>
               </Setter>
             </ControlTheme>
           </ItemsControl.ItemContainerTheme>

--- a/src/NodeEditorAvalonia/Themes/Controls/Toolbox.axaml
+++ b/src/NodeEditorAvalonia/Themes/Controls/Toolbox.axaml
@@ -2,8 +2,6 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:m="clr-namespace:NodeEditor.Model;assembly=NodeEditorAvalonia.Model"
                     xmlns:controls="clr-namespace:NodeEditor.Controls"
-                    xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
-                    xmlns:idd="clr-namespace:Avalonia.Xaml.Interactions.DragAndDrop;assembly=Avalonia.Xaml.Interactions.DragAndDrop"
                     xmlns:behaviors="clr-namespace:NodeEditor.Behaviors;assembly=NodeEditorAvalonia"
                     x:CompileBindings="True">
 
@@ -19,19 +17,19 @@
           <ListBox.Resources>
             <behaviors:TemplatesListBoxDropHandler x:Key="TemplatesListBoxDropHandler" />
           </ListBox.Resources>
-          <i:Interaction.Behaviors>
-            <idd:ContextDropBehavior Handler="{StaticResource TemplatesListBoxDropHandler}" />
-          </i:Interaction.Behaviors>
+          <Interaction.Behaviors>
+            <ContextDropBehavior Handler="{StaticResource TemplatesListBoxDropHandler}" />
+          </Interaction.Behaviors>
           <ListBox.Styles>
             <Style Selector="ListBox > ListBoxItem">
-              <Setter Property="(i:Interaction.Behaviors)">
-                <i:BehaviorCollectionTemplate>
-                  <i:BehaviorCollection>
-                    <idd:ContextDragBehavior />
+              <Setter Property="(Interaction.Behaviors)">
+                <BehaviorCollectionTemplate>
+                  <BehaviorCollection>
+                    <ContextDragBehavior />
                     <behaviors:InsertTemplateOnDoubleTappedBehavior
                       DrawingSource="{Binding DrawingSource, RelativeSource={RelativeSource TemplatedParent}}" />
-                  </i:BehaviorCollection>
-                </i:BehaviorCollectionTemplate>
+                  </BehaviorCollection>
+                </BehaviorCollectionTemplate>
               </Setter>
             </Style>
           </ListBox.Styles>


### PR DESCRIPTION
- fixes https://github.com/wieslawsoltes/NodeEditor/issues/74
- migrate from Avalonia.Xaml.Behaviors to Xaml.Behaviors.Avalonia
- migrate from Avalonia.Controls.PanAndZoom to PanAndZoom
- amend missing property 'ContextDropBehavior.DataFormat' in ToolboxDragBehavior.cs
- amend namespace aliases in Connectors, Editor, Node, Nodes, Pins, Toolbox and ToolboxView.axaml

BREAKING-CHANGE: Several package versions have been updated, along with some packages being changed for another. View the diff in Directory.Packages.props for more details